### PR TITLE
Add sf as weak dependency as suggested by sp package

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: nichenetr
 Type: Package
 Title: NicheNet: Modeling Intercellular Communication by Linking Ligands to Target Genes
-Version: 2.0.2
+Version: 2.0.3
 Authors@R: c(person("Robin", "Browaeys",  role = c("aut")),
             person("Chananchida", "Sang-aram", role = c("aut", "cre"), email = "chananchida.sangaram@ugent.be"))
 Description: This package allows you the investigate intercellular communication from a computational perspective. More specifically, it allows to investigate how interacting cells influence each other's gene expression. Functionalities of this package (e.g. including predicting extracellular upstream regulators and their affected target genes) build upon a probabilistic model of ligand-target links that was inferred by data-integration.
@@ -53,5 +53,6 @@ Suggests:
     mco,
     parallel,
     covr,
-    tidyverse
+    tidyverse,
+    sf
 VignetteBuilder: knitr


### PR DESCRIPTION
(see also https://r-spatial.org/r/2023/05/15/evolution4.html). Here is similar info that we see when nichenetr loads sp internally:

> library(nichenetr)
The legacy packages maptools, rgdal, and rgeos, underpinning the sp package, which was just loaded, will retire in October 2023. Please refer to R-spatial evolution reports for details, especially https://r-spatial.org/r/2023/05/15/evolution4.html. It may be desirable to make the sf package available; package maintainers should consider adding sf to Suggests:. The sp package is now running under evolution status 2
     (status 2 uses the sf package in place of rgdal)