### PR TITLE
Fix bugs in `assign_ligands_to_celltype`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: nichenetr
 Type: Package
 Title: NicheNet: Modeling Intercellular Communication by Linking Ligands to Target Genes
-Version: 2.1.1
+Version: 2.1.2
 Authors@R: c(person("Robin", "Browaeys",  role = c("aut")),
             person("Chananchida", "Sang-aram", role = c("aut", "cre"), email = "chananchida.sangaram@ugent.be"))
 Description: This package allows you the investigate intercellular communication from a computational perspective. More specifically, it allows to investigate how interacting cells influence each other's gene expression. Functionalities of this package (e.g. including predicting extracellular upstream regulators and their affected target genes) build upon a probabilistic model of ligand-target links that was inferred by data-integration.
@@ -10,7 +10,7 @@ Encoding: UTF-8
 LazyData: true
 URL: https://github.com/saeyslab/nichenetr
 BugReports: https://github.com/saeyslab/nichenetr/issues
-RoxygenNote: 7.1.2
+RoxygenNote: 7.3.1
 Depends: R (>= 3.0.0)
 Imports:
     tidyverse,

--- a/R/application_visualization.R
+++ b/R/application_visualization.R
@@ -787,7 +787,7 @@ make_mushroom_plot <- function(prioritization_table, top_n = 30, show_rankings =
 #' @param func.assign Function to use to assign a ligand to a cell type (default = mean + SD)
 #' @param condition_oi Condition of interest to subset the Seurat object (default = NULL)
 #' @param condition_col Metadata column name in the Seurat object that contains the condition of interest (default = NULL)
-#' @param ... Arguments passed to Seurat::GetAssayData for the slot/layer to use (default: data)
+#' @param ... Arguments passed to Seurat::GetAssayData, e.g., for the slot/layer to use (default: data)
 #' @return A data frame of two columns, the cell type the ligand has been assigned to (\code{ligand_type}) and the ligand name (\code{ligand})
 #' @details If the provided slot/layer is "data",  the normalized counts are first exponentiated before aggregation is performed
 #' @export
@@ -812,7 +812,7 @@ assign_ligands_to_celltype <- function(seuratObj, ligands, celltype_col, func.ag
   slot <- "data"
   # Check if slot or layer is provided
   if (length(list(...)) > 0) {
-    if (grepl("slot|layer", names(list(...)))){
+    if (any(grepl("slot|layer", names(list(...))))){
       slot <- list(...)[[which(grepl("slot|layer", names(list(...))))]]
     } else {
       warning("No slot/layer provided even though extra argument was provided, using default slot = 'data'")

--- a/R/application_visualization.R
+++ b/R/application_visualization.R
@@ -809,11 +809,14 @@ assign_ligands_to_celltype <- function(seuratObj, ligands, celltype_col, func.ag
     stop("Not all ligands are in the Seurat object")
   }
 
+  slot <- "data"
   # Check if slot or layer is provided
-  if (length(list(...)) > 0 & grepl("slot|layer", names(list(...)))) {
-    slot <- list(...)[[which(grepl("slot|layer", names(list(...))))]]
-  } else {
-    slot <- "data"
+  if (length(list(...)) > 0) {
+    if (grepl("slot|layer", names(list(...)))){
+      slot <- list(...)[[which(grepl("slot|layer", names(list(...))))]]
+    } else {
+      warning("No slot/layer provided even though extra argument was provided, using default slot = 'data'")
+    }
   }
 
   seuratObj_subset <- subset(seuratObj, features = ligands)

--- a/man/assign_ligands_to_celltype.Rd
+++ b/man/assign_ligands_to_celltype.Rd
@@ -4,7 +4,18 @@
 \alias{assign_ligands_to_celltype}
 \title{Assign ligands to cell types}
 \usage{
-assign_ligands_to_celltype(seuratObj, ligands, celltype_col, func.agg=mean, func.assign=function(x) mean(x) + sd(x), slot="data", condition_oi=NULL, condition_col=NULL)
+assign_ligands_to_celltype(
+  seuratObj,
+  ligands,
+  celltype_col,
+  func.agg = mean,
+  func.assign = function(x) {
+     mean(x) + sd(x)
+ },
+  condition_oi = NULL,
+  condition_col = NULL,
+  ...
+)
 }
 \arguments{
 \item{seuratObj}{Seurat object}
@@ -21,7 +32,7 @@ assign_ligands_to_celltype(seuratObj, ligands, celltype_col, func.agg=mean, func
 
 \item{condition_col}{Metadata column name in the Seurat object that contains the condition of interest (default = NULL)}
 
-\item{slot}{Slot in the Seurat object to use (default = "data"). If "data", the normalized counts are first exponentiated before aggregation is performed}
+\item{...}{Arguments passed to Seurat::GetAssayData for the slot/layer to use (default: data)}
 }
 \value{
 A data frame of two columns, the cell type the ligand has been assigned to (\code{ligand_type}) and the ligand name (\code{ligand})
@@ -29,11 +40,14 @@ A data frame of two columns, the cell type the ligand has been assigned to (\cod
 \description{
 Assign ligands to a sender cell type, based on the strongest expressing cell type of that ligand. Ligands are only assigned to a cell type if that cell type is the only one to show an expression that is higher than the average + SD. Otherwise, it is assigned to "General".
 }
+\details{
+If the provided slot/layer is "data",  the normalized counts are first exponentiated before aggregation is performed
+}
 \examples{
 \dontrun{
 assign_ligands_to_celltype(seuratObj = seuratObj, ligands = best_upstream_ligands[1:20],
                           celltype_col = "celltype", func.agg = mean, func.assign = function(x) {mean(x)+sd(x)},
-                          slot = "data", condition_oi = "LCMV", condition_col = "aggregate")
+                          condition_oi = "LCMV", condition_col = "aggregate", slot = "data")
 }
 
 }

--- a/man/assign_ligands_to_celltype.Rd
+++ b/man/assign_ligands_to_celltype.Rd
@@ -32,7 +32,7 @@ assign_ligands_to_celltype(
 
 \item{condition_col}{Metadata column name in the Seurat object that contains the condition of interest (default = NULL)}
 
-\item{...}{Arguments passed to Seurat::GetAssayData for the slot/layer to use (default: data)}
+\item{...}{Arguments passed to Seurat::GetAssayData, e.g., for the slot/layer to use (default: data)}
 }
 \value{
 A data frame of two columns, the cell type the ligand has been assigned to (\code{ligand_type}) and the ligand name (\code{ligand})


### PR DESCRIPTION
- Addition of the `if` statement and removal of `set_rownames` proposed by #268 
- Changed the `slot` parameter to `...` to accommodate both slot/layer terminology
- Also fixed mistake in hardcoding of `celltype` column name in two places

Example code:
```
seuratObj <- readRDS(url("https://zenodo.org/records/5840787/files/seurat_obj_subset_integrated_zonation.rds")) 
seuratObj <- UpdateSeuratObject(seuratObj)

seuratObj <- PrepSCTFindMarkers(seuratObj)
nichenet_output <- nichenet_seuratobj_cluster_de(
  seurat_obj = seuratObj, 
  sender = c("LSECs_portal", "Hepatocytes_portal", "Stellate cells_portal") , 
  receiver_affected = "KCs", 
  receiver_reference = c("MoMac1", "MoMac2"),
  ligand_target_matrix = ligand_target_matrix,
  lr_network = lr_network,
  weighted_networks = weighted_networks
)

assign_ligands_to_celltype(seuratObj, nichenet_output$top_ligands, celltype_col = "celltype", slot = "data")
```
This no longer produces an error.