### PR TITLE
Update alias_to_symbol_seurat() behavior for v5 objects

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: nichenetr
 Type: Package
 Title: NicheNet: Modeling Intercellular Communication by Linking Ligands to Target Genes
-Version: 2.1.5
+Version: 2.1.6
 Authors@R: c(person("Robin", "Browaeys",  role = c("aut")),
             person("Chananchida", "Sang-aram", role = c("aut", "cre"), email = "chananchida.sangaram@ugent.be"))
 Description: This package allows you the investigate intercellular communication from a computational perspective. More specifically, it allows to investigate how interacting cells influence each other's gene expression. Functionalities of this package (e.g. including predicting extracellular upstream regulators and their affected target genes) build upon a probabilistic model of ligand-target links that was inferred by data-integration.

--- a/R/supporting_functions.R
+++ b/R/supporting_functions.R
@@ -197,7 +197,7 @@ convert_alias_to_symbols = function(aliases, organism, verbose = TRUE){
 #' @description \code{alias_to_symbol_seurat} Convert aliases to official gene symbols in a Seurat Object. Makes use of `convert_alias_to_symbols`
 #' @usage alias_to_symbol_seurat(seurat_obj, organism)
 #'
-#' @param seurat_obj Seurat object
+#' @param seurat_obj Seurat object, v4 or below. For Seurat v5, a warning is thrown and the same object will be returned.
 #' @param organism Is Seurat object data from "mouse" or "human"
 #'
 #' @return Seurat object
@@ -219,12 +219,13 @@ alias_to_symbol_seurat = function(seurat_obj, organism) {
 
   # Stop if obj_version is seurat v5
   if (obj_version >= 5){
-    stop("This function is not supported for Seurat v5 objects. Consider using `convert_alias_to_symbols` on your original expression matrix and creating a new Seurat object instead.
+    warning("This function is not supported for Seurat v5 objects, so the same object will be returned. Consider using `convert_alias_to_symbols` on your original expression matrix and creating a new Seurat object instead.
          If this is not feasible, consider checking out Seurat.utils::RenameGenesSeurat.")
+
+    return(seurat_obj)
   }
 
   assays <- Assays(seurat_obj)
-
 
   convert_newnames <- function(feature_names, organism, verbose = FALSE) {
       newnames <- convert_alias_to_symbols(feature_names, organism = organism, verbose = verbose)

--- a/man/alias_to_symbol_seurat.Rd
+++ b/man/alias_to_symbol_seurat.Rd
@@ -7,7 +7,7 @@
 alias_to_symbol_seurat(seurat_obj, organism)
 }
 \arguments{
-\item{seurat_obj}{Seurat object}
+\item{seurat_obj}{Seurat object, v4 or below. For Seurat v5, a warning is thrown and the same object will be returned.}
 
 \item{organism}{Is Seurat object data from "mouse" or "human"}
 }

--- a/tests/testthat/test-prioritization.R
+++ b/tests/testthat/test-prioritization.R
@@ -11,7 +11,7 @@ test_that("Wrapper function for seurat", {
   if (as.numeric(substr(packageVersion("Seurat"), 1, 1)) < 5){
     seurat_obj_test = alias_to_symbol_seurat(seurat_obj_test, "mouse")
   } else if (grepl("^5", packageVersion("Seurat")) & grepl("^5", seurat_obj_test@version)){
-    expect_error(alias_to_symbol_seurat(seurat_obj_test, "mouse"))
+    expect_warning(alias_to_symbol_seurat(seurat_obj_test, "mouse"))
   }
 
   lr_network_filtered <- lr_network %>% filter(from %in% rownames(seurat_obj_test), to %in% rownames(seurat_obj_test))
@@ -138,7 +138,7 @@ test_that("Prioritization scheme works", {
       pct <- pcts[i]
 
       if (grepl("^5", packageVersion("Seurat"))){
-        expect_error(alias_to_symbol_seurat(seurat_obj_test, "mouse"))
+        expect_warning(alias_to_symbol_seurat(seurat_obj_test, "mouse"))
       } else {
         seurat_obj_test <- alias_to_symbol_seurat(seurat_obj_test, "mouse")
       }

--- a/tests/testthat/test-symbol_conversion.R
+++ b/tests/testthat/test-symbol_conversion.R
@@ -31,15 +31,17 @@ test_that("Seurat alias conversion works", {
   seurat_object_lite = readRDS(url("https://zenodo.org/record/3531889/files/seuratObj_test.rds"))
 
   seurat_object_lite2 = seurat_object_lite %>% alias_to_symbol_seurat(organism = "mouse")
-  testthat::expect_equal(typeof(seurat_object_lite2), "S4")
+  expect_equal(typeof(seurat_object_lite2), "S4")
 
   seurat_object_lite <- UpdateSeuratObject(seurat_object_lite)
 
   if (grepl("^5", packageVersion("Seurat")) & grepl("^5", seurat_object_lite@version)){
-    expect_error(alias_to_symbol_seurat(seurat_object_lite, "mouse"))
+    expect_warning(alias_to_symbol_seurat(seurat_object_lite, "mouse"))
+    same_seurat_obj <- suppressWarnings(alias_to_symbol_seurat(seurat_object_lite, "mouse"))
+    expect_true(all(rownames(seurat_object_lite) == rownames(same_seurat_obj)))
   } else {
     seurat_object_lite2 = seurat_object_lite %>% alias_to_symbol_seurat(organism = "mouse")
-    testthat::expect_equal(typeof(seurat_object_lite2), "S4")
+    expect_equal(typeof(seurat_object_lite2), "S4")
   }
 
 })


### PR DESCRIPTION
When using alias_to_symbol_seurat() with Seurat v5 objects, the function now returns a warning instead of an error. The input object is then returned to the user.